### PR TITLE
Threads Clone: Add Bottom Bar

### DIFF
--- a/components/shared/BottomBar.tsx
+++ b/components/shared/BottomBar.tsx
@@ -1,5 +1,13 @@
+'use client';
+
 const BottomBar = () => {
-  return <div>BottomBar</div>;
+  return (
+    <footer className="fixed bottom-0 z-10 w-full rounded-t-3xl bg-tc-dark-300 p-4 px-7 backdrop-blur-lg md:hidden">
+      <div className="gap-3sm:gap-5 flex items-center justify-between text-white">
+        Bottom bar
+      </div>
+    </footer>
+  );
 };
 
 export default BottomBar;

--- a/components/shared/BottomBar.tsx
+++ b/components/shared/BottomBar.tsx
@@ -25,7 +25,7 @@ const BottomBar = () => {
             )}
           >
             <Image src={link.iconURL} alt={link.label} width={24} height={24} />
-            <p className="text-xs font-medium leading-4 text-tc-light-100 max-md:hidden">
+            <p className="text-xs font-medium leading-4 text-tc-light-100 max-sm:hidden">
               {link.label.split(/\s+/)[0]}
             </p>
           </Link>

--- a/components/shared/BottomBar.tsx
+++ b/components/shared/BottomBar.tsx
@@ -1,10 +1,35 @@
 'use client';
 
+import clsx from 'clsx';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import sidebarLinks from '@/constants';
+
 const BottomBar = () => {
+  const pathname = usePathname();
+
   return (
     <footer className="fixed bottom-0 z-10 w-full rounded-t-3xl bg-tc-dark-300 p-4 px-7 backdrop-blur-lg md:hidden">
-      <div className="gap-3sm:gap-5 flex items-center justify-between text-white">
-        Bottom bar
+      <div className="gap-3sm:gap-5 flex items-center justify-between">
+        {sidebarLinks.map((link) => (
+          <Link
+            href={link.route}
+            key={link.id}
+            className={clsx(
+              'relative flex flex-col items-center gap-2 rounded-lg p-2 sm:flex-1 sm:px-2 sm:py-2.5',
+              {
+                'bg-tc-primary': pathname === link.route,
+              },
+            )}
+          >
+            <Image src={link.iconURL} alt={link.label} width={24} height={24} />
+            <p className="text-xs font-medium leading-4 text-tc-light-100 max-md:hidden">
+              {link.label.split(/\s+/)[0]}
+            </p>
+          </Link>
+        ))}
       </div>
     </footer>
   );


### PR DESCRIPTION
### Description

This pull request introduces a bottom bar to the project, featuring navigation items with icons. The active navigation item is highlighted dynamically. The `clsx` package is incorporated to facilitate dynamic class changes. Moreover, responsive styles are implemented to display only icons for navigation items on screens smaller than `sm`.

### Changes Made

- Implemented a bottom bar with navigation items and icons.
- Achieved dynamic highlighting of the active navigation item.
- Integrated the `clsx` package for efficient dynamic class changes.
- Established responsive styles to exclusively display icons for navigation items on screens below the `sm` breakpoint.

### Checklist

- [x] Added bottom bar with navigation items and icons.
- [x] Realized dynamic highlighting of the active navigation item.
- [x] Utilized the `clsx` package for dynamic class changes.
- [x] Tested responsiveness and cross-device compatibility.

### Screenshots

| `sm` | `xs` |
| --- | --- |
|  ![image](https://github.com/shahadat3669/threads-clone/assets/55840999/618312c5-7b21-4825-9bdb-346c0f2970ce) | ![image](https://github.com/shahadat3669/threads-clone/assets/55840999/17bbec87-2955-48f0-96b1-973a7635e3a6)|