### PR TITLE
Threads Clone: Add "Create Thread" Functionality

### DIFF
--- a/app/(root)/create-thread/page.tsx
+++ b/app/(root)/create-thread/page.tsx
@@ -1,0 +1,27 @@
+import { currentUser } from '@clerk/nextjs';
+import { redirect } from 'next/navigation';
+
+import PostThread from '@/components/forms/PostThread';
+import { fetchUser } from '@/lib/actions/user.actions';
+
+const page = async () => {
+  const user = await currentUser();
+  if (!user) return null;
+
+  const userInfo = await fetchUser(user.id);
+  if (!userInfo?.onboard) redirect('/onboarding');
+  // eslint-disable-next-line no-underscore-dangle
+  const id = userInfo._id.toString();
+  return (
+    <section className="flex min-h-screen flex-1 flex-col items-center bg-tc-dark-400 px-6 pb-10 pt-28 max-md:pb-32 sm:px-10">
+      <div className="w-full max-w-4xl">
+        <h1 className="text-3xl font-bold leading-[140%] text-tc-light-100">
+          Create Threads
+        </h1>
+        <PostThread userId={id} btnTitle="Post Thread" />
+      </div>
+    </section>
+  );
+};
+
+export default page;

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
       <html lang="en">
         <body className={inter.className}>
           <TopBar />
-          <main>
+          <main className="flex flex-row">
             <LeftSidebar />
             {children}
             <RightSidebar />

--- a/components/forms/PostThread.tsx
+++ b/components/forms/PostThread.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { usePathname, useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import type { z } from 'zod';
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { createThread } from '@/lib/actions/thread.actions';
+import { threadValidation } from '@/lib/validations/thread';
+
+import { Button } from '../ui/button';
+import { Textarea } from '../ui/textarea';
+
+type Props = {
+  userId: string;
+  btnTitle: string;
+};
+
+const PostThread = ({ userId, btnTitle }: Props) => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const form = useForm<z.infer<typeof threadValidation>>({
+    resolver: zodResolver(threadValidation),
+    defaultValues: {
+      thread: '',
+      accountId: userId,
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof threadValidation>) => {
+    await createThread({
+      text: values.thread,
+      author: userId,
+      path: pathname,
+    });
+    router.push('/');
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        className="mt-10 flex flex-col justify-start gap-10"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
+        <FormField
+          control={form.control}
+          name="thread"
+          render={({ field }) => (
+            <FormItem className="flex w-full flex-col gap-3">
+              <FormLabel className="text-base font-semibold leading-[140%] text-tc-light-200">
+                Content
+              </FormLabel>
+              <FormControl className="border !border-tc-dark-300 !bg-tc-dark-300 text-tc-light-100 focus-visible:ring-0 focus-visible:ring-transparent focus-visible:ring-offset-0">
+                <Textarea rows={15} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="!bg-tc-primary !text-tc-light-100">
+          {btnTitle}
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default PostThread;

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -1,0 +1,33 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import Thread from '../models/thread.model';
+import User from '../models/user.model';
+import { connectToDB } from '../mongoose';
+
+interface Params {
+  text: string;
+  author: string;
+  path: string;
+}
+
+export const createThread = async ({ text, author, path }: Params) => {
+  try {
+    connectToDB();
+
+    const createdThread = await Thread.create({
+      text,
+      author,
+    });
+
+    await User.findByIdAndUpdate(author, {
+      // eslint-disable-next-line no-underscore-dangle
+      $push: { threads: createdThread._id },
+    });
+
+    revalidatePath(path);
+  } catch (error: any) {
+    throw new Error(`Failed to create thread: ${error.message}`);
+  }
+};

--- a/lib/models/thread.model.ts
+++ b/lib/models/thread.model.ts
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+
+const threadSchema = new mongoose.Schema({
+  text: {
+    type: String,
+    required: true,
+  },
+  author: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  parentId: {
+    type: String,
+  },
+  children: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Thread',
+    },
+  ],
+});
+
+const Thread = mongoose.models.Thread || mongoose.model('Thread', threadSchema);
+
+export default Thread;

--- a/lib/models/user.model.ts
+++ b/lib/models/user.model.ts
@@ -20,6 +20,12 @@ const userSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  threads: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Thread',
+    },
+  ],
 });
 
 const User = mongoose.models.User || mongoose.model('User', userSchema);

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -1,0 +1,6 @@
+import * as z from 'zod';
+
+export const threadValidation = z.object({
+  thread: z.string().nonempty().min(3, { message: 'Minimum 3 characters.' }),
+  accountId: z.string(),
+});


### PR DESCRIPTION
### Description

This pull request introduces the "Create Thread" functionality, allowing users to create new threads. A new thread model has been added, establishing a many-to-one relationship with users. The thread creation form validates user input before adding the new thread to the database.

### Changes Made

- Added a "Create Thread" page with a thread creation form.
- Created a new thread model with a many-to-one relationship to users.
- Implemented thread validation to ensure valid user input.
- Added an action file for creating new threads and storing them in the database.

### Checklist

- [x] Added "Create Thread" page with thread creation form.
- [x] Implemented thread model with many-to-one relationship to users.
- [x] Implemented thread validation to ensure valid input.
- [x] Created action file for creating and storing new threads.

### Screenshots
![image](https://github.com/shahadat3669/threads-clone/assets/55840999/652082a4-c848-4db1-82ed-4ac3e201dd29)
